### PR TITLE
Changing to lower case

### DIFF
--- a/sfcasts/stimulus/ajax-html.md
+++ b/sfcasts/stimulus/ajax-html.md
@@ -1,10 +1,10 @@
 # HTML-Returning Ajax Endpoint
 
-When we type in the box, we *are* now making an AJAX request back to the server.
+When we type in the box, we *are* now making an Ajax request back to the server.
 The response - which we can see in the log - is the *full* HTML of the homepage.
 That's... not what we want. But... what *do* we want?
 
-If you use something like React or Vue, your AJAX endpoints probably return JSON.
+If you use something like React or Vue, your Ajax endpoints probably return JSON.
 You then use that JSON to build the HTML in JavaScript. But we're using Stimulus!
 And Stimulus is *all* about building HTML on the server.
 
@@ -13,7 +13,7 @@ going to return an HTML *fragment*: *just* the HTML needed for the "search
 suggestions" area.
 
 Head over to `ProductController` and, before the return, add an if statement: if
-`$request->query->get('preview')`, then we know this is the suggestions AJAX request.
+`$request->query->get('preview')`, then we know this is the suggestions Ajax request.
 Inside, render a new template: `return $this->render()` and call it
 `product/_searchPreview.html.twig`.
 
@@ -53,9 +53,9 @@ Variable `products` does not exist. Because... in the controller, I forgot my "s
 Now... much better. I mean, it looks terrible *here*, but that's just because this
 page doesn't have any CSS. Head back to the homepage.
 
-## Adding the AJAX HTML to the Target
+## Adding the Ajax HTML to the Target
 
-The last step in Stimulus is to dump the HTML from the AJAX endpoint onto the page.
+The last step in Stimulus is to dump the HTML from the Ajax endpoint onto the page.
 To control exactly where it goes, let's add a new target element. In
 `index.html.twig`, I want the content to go right below the `input`. Add a
 `<div>`... with `class="search-preview"`. That's a class that already lives in our

--- a/sfcasts/stimulus/ajax-html.md
+++ b/sfcasts/stimulus/ajax-html.md
@@ -1,4 +1,4 @@
-# HTML-Returning AJAX Endpoint
+# HTML-Returning Ajax Endpoint
 
 When we type in the box, we *are* now making an AJAX request back to the server.
 The response - which we can see in the log - is the *full* HTML of the homepage.

--- a/sfcasts/stimulus/fetch.md
+++ b/sfcasts/stimulus/fetch.md
@@ -114,7 +114,7 @@ call, we - of course - need to await for it to finish. But even getting the
 body of the response - with `response.text()` - is an asynchronous operation that
 returns a `Promise`. That's... kind of odd... but ok: we just need to `await` it.
 
-Ok, testing time! Refresh and... type! Yes! I can already see new AJAX requests
+Ok, testing time! Refresh and... type! Yes! I can already see new Ajax requests
 popping into the web debug toolbar! *And* the console is dumping the HTML.
 
 The only problem is that this is the *full* HTML of the homepage... which isn't

--- a/sfcasts/stimulus/fetch.md
+++ b/sfcasts/stimulus/fetch.md
@@ -3,13 +3,13 @@
 To make the Ajax request inside the controller, I'm going to use the `fetch()`
 function.
 
-## fetch() for AJAX
+## fetch() for Ajax
 
 If you don't know, `fetch()` is a built-in function for making Ajax calls that
 *most* browsers support. So basically... pretty much all browsers except for IE 11.
 
 If you *do* need to support IE 11, you have two options. First, the other library
-I really like for making AJAX requests is called Axios, which you can install
+I really like for making Ajax requests is called Axios, which you can install
 with `yarn add axios`. We use it in our Vue tutorial. It also has a few more
 features than fetch.
 
@@ -29,9 +29,9 @@ Encore
 
 ## Using URLSearchParams() & its Polyfill
 
-*Anyways*, let's make the AJAX call!
+*Anyways*, let's make the Ajax call!
 
-We need to send 2 query parameters on the AJAX request: the value of
+We need to send 2 query parameters on the Ajax request: the value of
 the search box as a `q` query parameter and another one called `preview` so that
 our controller knows to render the preview HTML.
 
@@ -78,9 +78,9 @@ Encore
 ```
 ***
 
-## Making the AJAX Request with fetch()
+## Making the Ajax Request with fetch()
 
-Ok, let's make the AJAX call: say `fetch()` then pass it the fancy ticks so we can
+Ok, let's make the Ajax call: say `fetch()` then pass it the fancy ticks so we can
 create a dynamic string. We need `${this.urlValue}` then a question mark and another
 `${}` with `params.toString()`. That builds the query string with the `&` symbols.
 
@@ -93,7 +93,7 @@ a callback.
 *Or*, we can use `await`... which I like because it looks simpler. Remove
 the `.then()` and instead say `const response = await fetch(...)`.
 
-This will *wait* for the AJAX call to finish and set the result to the `response`
+This will *wait* for the Ajax call to finish and set the result to the `response`
 variable. But as *soon* as you use `await`, you must add `async` before whatever
 function that you're inside of. Yup, that makes my build happy.
 

--- a/sfcasts/stimulus/modal-form.md
+++ b/sfcasts/stimulus/modal-form.md
@@ -34,7 +34,7 @@ always make them dynamic later.
 
 Let's make sure we didn't break anything. When I click the button, very nice!
 
-## Passing the Form AJAX URL to the Stimulus Controller
+## Passing the Form Ajax URL to the Stimulus Controller
 
 To get the new product form HTML, when the modal opens, we're going to make an Ajax
 call to an endpoint that will *return* that HTML.
@@ -120,7 +120,7 @@ equals `Loading...`.
 [[[ code('94960f6d81') ]]]
 
 That's a minor thing: if we open the modal twice, this will clear the contents
-before we start the AJAX call... so that we don't temporarily see an *old* form.
+before we start the Ajax call... so that we don't temporarily see an *old* form.
 
 ## The Form HTML Endpoint
 

--- a/sfcasts/stimulus/options-form-ajax.md
+++ b/sfcasts/stimulus/options-form-ajax.md
@@ -36,7 +36,7 @@ you can choose from - and `confirmButtonText` set to "yes, remove it".
 Let's check it! Refresh and remove. That looks awesome! And more importantly, we
 can now properly re-use this on any form.
 
-## Submitting via AJAX
+## Submitting via Ajax
 
 While we're here, I want to add one more option to our controller: the ability to
 submit the form - after confirmation - via Ajax instead of a *normal* form submit.
@@ -50,7 +50,7 @@ any form via Ajax. So definitely check that out.
 But doing this with Stimulus will be a good exercise and *will* give us more
 control and flexibility over the process... which you sometimes need.
 
-## Setting up SweetAlert for the AJAX Submit
+## Setting up SweetAlert for the Ajax Submit
 
 Ok: to support submitting via Ajax, we need to tweak our SweetAlert config. Add
 a `showLoaderOnConfirm` key set to true. Then add a `preConfirm` option set to
@@ -70,7 +70,7 @@ modal will stay open and show a loading icon until that Ajax call finishes.
 
 Let's make sure we've got it hooked up. Refresh, and... yes! There's the log.
 
-## Submitting a Form via AJAX
+## Submitting a Form via Ajax
 
 Now let's actually *submit* that form via Ajax. Replace the `console.log()` with
 `return fetch()`. For the URL, `this.element` is a form... so we can use

--- a/sfcasts/stimulus/product-crud.md
+++ b/sfcasts/stimulus/product-crud.md
@@ -20,7 +20,7 @@ automatically happen via Ajax. My point is: Turbo will allow us to have a slick
 user interface... while writing *less* custom JavaScript. But if you *ever* want
 to do something extra, you are *completely* free to write custom JavaScript.
 
-## Let's Build an AJAX Form Modal!
+## Let's Build an Ajax Form Modal!
 
 In that spirit, after talking with a few of you wonderful people, I thought it might
 be good to show how we could submit a full form via Ajax, including handling

--- a/sfcasts/stimulus/properties-events.md
+++ b/sfcasts/stimulus/properties-events.md
@@ -42,19 +42,19 @@ increments and prints in the element. And, most importantly, we can see that eac
 element is working independently. This proves that there are two separate objects
 with two separate `count` properties.
 
-## When data-controller Elements are Loaded via AJAX
+## When data-controller Elements are Loaded via Ajax
 
 This isn't even my favorite part of Stimulus. Down in your browser's inspector,
 right click on the div around one of our controllers and go to "Edit as HTML".
 Copy the `<div data-controller>` and paste to hack in a new one right above it.
 
 What I'm doing is imitating what happens when HTML is added to the page after
-it's done loading, like via an AJAX call. This is a *classic* problem with JavaScript.
+it's done loading, like via an Ajax call. This is a *classic* problem with JavaScript.
 Suppose you have some jQuery code that attaches a `click` event listener to all
 elements that have some class. Usually, that code runs when the page finishes
 loading.
 
-Now, what happens if you load *new* HTML onto the page later via AJAX and the
+Now, what happens if you load *new* HTML onto the page later via Ajax and the
 HTML contains an element with that class? Is the event listener automatically
 attached to it? Nope! It's not... unless you go to the hassle of manually re-calling
 your function that attaches the event listener.
@@ -65,7 +65,7 @@ So: can stimulus handle this? Can it somehow "notice" that a new element with
 When I click off to add the new element to the page... it works! Behind the
 scenes Stimulus actually *did* notice that a new element was added to the page and
 instantiated a brand new controller object for it. That's incredible! It's
-a game-changer! I can now write nice controller classes, return HTML via AJAX and
+a game-changer! I can now write nice controller classes, return HTML via Ajax and
 *not* have to worry about re-initializing behavior on that new HTML.
 
 And, of course, the controller works exactly like the other ones: it increments as

--- a/sfcasts/stimulus/properties-events.md
+++ b/sfcasts/stimulus/properties-events.md
@@ -1,4 +1,4 @@
-# Magic with Events, Properties & HTML from AJAX
+# Magic with Events, Properties & HTML from Ajax
 
 To show off the power of this simple, controller-instance-bound-to-HTML-element
 concept, let's count how many times each element is clicked and print that inside

--- a/sfcasts/stimulus/ux.md
+++ b/sfcasts/stimulus/ux.md
@@ -36,7 +36,7 @@ of this concept.
 Ok: so what does this mean for us? Having a beautiful & interactive user interface
 requires two things. First, we need a way to write professional JavaScript... not
 1000 line long jQuery files, or one-off scripts. And we need that JavaScript to
-work... *even* if we load some HTML via AJAX. That's a classic problem with JavaScript:
+work... *even* if we load some HTML via Ajax. That's a classic problem with JavaScript:
 behavior isn't necessarily applied to HTML elements that arrive on the page later.
 
 This is all solved with Stimulus: a tiny JavaScript library *and* the topic of
@@ -47,7 +47,7 @@ That's handled by Turbo: the topic of the next tutorial.
 
 Put Stimulus and Turbo together and suddenly you can write clean JavaScript that
 always works *and* have a site where every link click and form submit loads via
-AJAX. So basically: the single page application experience... without the hassle of
+Ajax. So basically: the single page application experience... without the hassle of
 building a single page application.
 
 And if you're wondering: does this kill frontend frameworks like React or Vue?

--- a/sfcasts/stimulus/value-change.md
+++ b/sfcasts/stimulus/value-change.md
@@ -145,5 +145,5 @@ And look at it! It's less than *30* lines of code and is *incredibly* readable.
 *This* is how I want my JavaScript to look.
 
 Head back to the homepage of our site. This has a functional search... but it's
-*so* boring. Next: let's add an AJAX-powered "quick search" that shows
+*so* boring. Next: let's add an Ajax-powered "quick search" that shows
 matching results under the search box as we type.

--- a/sfcasts/turbo/frame-redirect.md
+++ b/sfcasts/turbo/frame-redirect.md
@@ -60,7 +60,7 @@ frame. So when we click the edit link from the product show page, that Ajax requ
 *will* add a `Turbo-Frame` header. You can see it all the way down here under request
 headers... there it is: `Turbo-Frame: product-info`.
 
-But when navigate directly to the product admin area and look at *that* AJAX request,
+But when navigate directly to the product admin area and look at *that* Ajax request,
 down here, there is *no* `Turbo-Frame` header. This means we can detect whether
 a request is being loaded inside a turbo frame from inside of Symfony!
 

--- a/sfcasts/turbo/no-preview.md
+++ b/sfcasts/turbo/no-preview.md
@@ -27,7 +27,7 @@ for the registration page. That means the snapshot was for a page that had
 filled-in form fields and validation errors.
 
 Then, when we clicked back to the registration page, that snapshot was restored
-with errors and all. A moment later, when the AJAX call finished, the fresh content -
+with errors and all. A moment later, when the Ajax call finished, the fresh content -
 with an empty form - replaced the snapshot.
 
 This is a known issue with submitted forms. And... well... maybe it's not really an

--- a/sfcasts/turbo/reviews-frame.md
+++ b/sfcasts/turbo/reviews-frame.md
@@ -63,7 +63,7 @@ one before... but now it's gone! What happened?
 Look back at the network tools. There are *two* new requests.
 
 The first is a POST request to `/reviews`. That processed our form, was successful,
-and returned a 302 redirect *back* to the same URL. This caused a *second* AJAX
+and returned a 302 redirect *back* to the same URL. This caused a *second* Ajax
 request to be made to `/reviews` and *this* is what was used to fill in the
 `turbo-frame`.
 


### PR DESCRIPTION
AJAX is spelled inconsistently throughout the course. Can you do a full-text search for "AJAX"?